### PR TITLE
Correct path for template files

### DIFF
--- a/01-path-basics/103-kubernetes-concepts/readme.adoc
+++ b/01-path-basics/103-kubernetes-concepts/readme.adoc
@@ -19,7 +19,7 @@ This chapter uses a cluster with 3 master nodes and 5 worker nodes as described 
 All configuration files for this chapter are in the `01-path-basics/103-kubernetes-concepts/templates` directory.
 Please be sure to `cd` into that directory before running the commands below.
 
-    $ cd 01-path-basics/103-kubernetes-concepts/templates
+    $ cd ~/environment/aws-workshop-for-kubernetes/01-path-basics/103-kubernetes-concepts/templates
 
 == Display Nodes
 


### PR DESCRIPTION
At this point the user is in `~/environment` and the example command is missing `aws-workshop-for-kubernetes`.  Providing the full path will ensure the user will end up in the correct location regardless of what their current working directory is.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
